### PR TITLE
BCP-368: Postal code validation in create facility form.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7714,9 +7714,9 @@
       }
     },
     "moh-common-lib": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/moh-common-lib/-/moh-common-lib-3.0.12.tgz",
-      "integrity": "sha512-JhOhcbm/wmpFblHH+TjbzW1uryy3Hv2lGru6/a1u4UTtQcDyv8aLhQULLyTnWpR/1DjRsV/wdmnJc5bjnEpdCQ==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/moh-common-lib/-/moh-common-lib-3.0.13.tgz",
+      "integrity": "sha512-wGLaFM0thwo3LqyQ5Q9KYaGWDEItuicB4QQorF5lwGZ1kQI8hH8635TElLrwjlS293YaZtd3VPLQ4yMyh5JLZQ==",
       "requires": {
         "tslib": "^1.9.0",
         "zxcvbn": "^4.4.2"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "core-js": "^3.2.1",
     "date-fns": "^2.5.1",
     "font-awesome": "^4.6.3",
-    "moh-common-lib": "^3.0.12",
+    "moh-common-lib": "^3.0.13",
     "moment": "^2.24.0",
     "mygovbc-bootstrap-theme": "^0.4.0",
     "ngx-bootstrap": "^5.1.2",

--- a/src/app/modules/core-bcp/models/base-api.model.ts
+++ b/src/app/modules/core-bcp/models/base-api.model.ts
@@ -37,6 +37,7 @@ export interface FacilityValidationPartial {
   facilityName: string;
   // number must populated for practitioner registration, otherwise null
   number: string;
+  facilityCity?: string;
   postalCode: string;
 }
 

--- a/src/app/modules/create-facility/pages/facility-info/facility-info.component.html
+++ b/src/app/modules/create-facility/pages/facility-info/facility-info.component.html
@@ -67,6 +67,9 @@
                             label='Postal code'
                             placeholder=''
                             formControlName='postalCode'></common-postal-code>
+        <common-error-container [displayError]="showInvalidPostalCodeError">
+          <div>The postal code does not match the city provided.</div>
+        </common-error-container>
       </div>
 
       <div class="form-group">

--- a/src/app/modules/create-facility/pages/facility-info/facility-info.component.html
+++ b/src/app/modules/create-facility/pages/facility-info/facility-info.component.html
@@ -68,7 +68,7 @@
                             placeholder=''
                             formControlName='postalCode'></common-postal-code>
         <common-error-container [displayError]="showInvalidPostalCodeError">
-          <div>The postal code does not match the city provided.</div>
+          <div>{{invalidPostalCodeErrorMessage}}</div>
         </common-error-container>
       </div>
 
@@ -162,6 +162,9 @@
                               placeholder=''
                               formControlName="mailingPostalCode">
           </common-postal-code>
+          <common-error-container [displayError]="showInvalidMailingPostalCodeError">
+            <div>{{invalidPostalCodeErrorMessage}}</div>
+          </common-error-container>
         </div>
 
       </form>

--- a/src/app/modules/create-facility/pages/facility-info/facility-info.component.ts
+++ b/src/app/modules/create-facility/pages/facility-info/facility-info.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, ChangeDetectorRef } from '@angular/core';
 import { Router } from '@angular/router';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { cCreateFacilityValidators, validMultiFormControl } from '../../models/validators';
-import { Address, getProvinceDescription, ErrorMessage, ContainerService } from 'moh-common-lib';
+import { Address, getProvinceDescription, ErrorMessage, ContainerService, scrollToError } from 'moh-common-lib';
 import { CreateFacilityDataService } from '../../services/create-facility-data.service';
 import { CREATE_FACILITY_PAGES } from '../../create-facility-route-constants';
 import { stripPostalCodeSpaces } from '../../../core-bcp/models/helperFunc';
@@ -22,6 +22,7 @@ import { IRadioItems } from 'moh-common-lib/lib/components/radio/radio.component
 export class FacilityInfoComponent extends BcpBaseForm implements OnInit {
 
   systemDownError = false;
+  showInvalidPostalCodeError: boolean = false;
 
   // Error Messages
   qualifyBcpError: ErrorMessage = {
@@ -192,7 +193,7 @@ export class FacilityInfoComponent extends BcpBaseForm implements OnInit {
   continue() {
     this.updateDataService();
 
-
+    
     // todo: fix common-components issues - Not issues as the abstract form is using Template Forms not Reactive
     // note in common-library that this need to be addressed.
     this.facilityForm.markAllAsTouched();
@@ -201,42 +202,59 @@ export class FacilityInfoComponent extends BcpBaseForm implements OnInit {
       this.pageStateService.setPageComplete();
       this.containerService.setIsLoading();
 
-      this.api.validateFacility({
-        facilityName: this.dataService.facInfoFacilityName,
-        number: null,
-        // API expects postalCode without any spaces in it
-        postalCode: stripPostalCodeSpaces(this.dataService.facInfoPostalCode)
-      }, this.dataService.applicationUUID)
-        .subscribe((res: ValidationResponse) => {
-          this.dataService.jsonFacilityValidation.response = res;
+      const physicalAddressValidationPromise = new Promise((resolve, reject) => {
+        this.api.validateFacility({
+          facilityName: this.dataService.facInfoFacilityName,
+          number: null,
+          facilityCity: this.dataService.facInfoCity,
+          // API expects postalCode without any spaces in it
+          postalCode: stripPostalCodeSpaces(this.dataService.facInfoPostalCode)
+        }, this.dataService.applicationUUID)
+          .subscribe((res: ValidationResponse) => {
+            this.dataService.jsonFacilityValidation.response = res;
 
-          this.splunkLoggerService.log(
-              this.dataService.getSubmissionLogObject<ValidationResponse>(
-                'Validate Facility',
-                this.dataService.jsonFacilityValidation.response
-              )
-          );
+            this.splunkLoggerService.log(
+                this.dataService.getSubmissionLogObject<ValidationResponse>(
+                  'Validate Facility',
+                  this.dataService.jsonFacilityValidation.response
+                )
+            );
 
-          if (res.returnCode === ReturnCodes.SUCCESS) {
-            this.handleAPIValidation(true);
-            this.dataService.validateFacilityMessage = res.message;
-          } else {
-            if (Number(res.returnCode) <= Number(ReturnCodes.SYSTEM_ERROR)) {
-              // Set to near match so that document is sent to MAXIMAGE
-              this.dataService.validateFacilityMessage = 'UNKNOWN';
-            } else {
+            if (res.returnCode === ReturnCodes.SUCCESS) {
+              this.handleAPIValidation(true);
               this.dataService.validateFacilityMessage = res.message;
+              resolve();
+            } else {
+              if (Number(res.returnCode) <= Number(ReturnCodes.FAILURE)) {
+                // Message: CITY NOT VALID FOR POSTAL CODE
+                this.handlePostalCodeValidationFailure();
+                reject();
+              } else {
+                if (Number(res.returnCode) <= Number(ReturnCodes.SYSTEM_ERROR)) {
+                  // Set to near match so that document is sent to MAXIMAGE
+                  this.dataService.validateFacilityMessage = 'UNKNOWN';
+                } else {
+                  this.dataService.validateFacilityMessage = res.message;
+                }
+                // we treat near match or exact match the same
+                this.handleAPIValidation(false);
+                resolve();
+              }
             }
-            // we treat near match or exact match the same
-            this.handleAPIValidation(false);
-          }
-
-          this.navigate(CREATE_FACILITY_PAGES.REVIEW.fullpath);
-
-        }, error => {
-          // console.log('apiService onerror', error);
-          this.handleError();
-        });
+          }, error => {
+            // console.log('apiService onerror', error);
+            this.handleError();
+          });
+      });
+      Promise.all([
+        physicalAddressValidationPromise
+      ]).then(() => {
+        this.navigate(CREATE_FACILITY_PAGES.REVIEW.fullpath);
+      }).catch(() => {
+        setTimeout(() => {
+          scrollToError();
+        }, 50);
+      });
     }
   }
 
@@ -275,6 +293,7 @@ export class FacilityInfoComponent extends BcpBaseForm implements OnInit {
   private handleError(): void {
     this.systemDownError = true;
     this.containerService.setIsLoading(false);
+    this.showInvalidPostalCodeError = false;
     this.cdr.detectChanges();
   }
 
@@ -282,6 +301,15 @@ export class FacilityInfoComponent extends BcpBaseForm implements OnInit {
     this.systemDownError = false;
     this.containerService.setIsLoading(false);
     this.dataService.apiDuplicateWarning = !isValid;
+    this.showInvalidPostalCodeError = false;
+    this.cdr.detectChanges();
+  }
+
+  handlePostalCodeValidationFailure() {
+    this.showInvalidPostalCodeError = true;
+    this.systemDownError = false;
+    this.containerService.setIsLoading(false);
+    this.dataService.apiDuplicateWarning = false;
     this.cdr.detectChanges();
   }
 

--- a/src/app/modules/practitioner-registration/pages/facility-info/facility-info.component.ts
+++ b/src/app/modules/practitioner-registration/pages/facility-info/facility-info.component.ts
@@ -90,6 +90,7 @@ export class FacilityInfoComponent extends BcpBaseForm implements OnInit, AfterV
         facilityName: null,
         number: this.dataService.pracFacilityNumber,
         // API expects postalCode without any spaces in it
+        facilityCity: null,
         postalCode: stripPostalCodeSpaces(this.dataService.pracFacilityPostalCode)
       }, this.dataService.applicationUUID)
         .subscribe((res: ValidationResponse) => {


### PR DESCRIPTION
Moved the API requests to promise-based system in order to use the `Promise.all` function, to detect when both (now 2) API requests are complete.